### PR TITLE
Add job extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,27 @@ end
 | `backtrace` |  `5`      | number of backtrace lines to show in case of failures. Can be `true`, `false` or a number of lines to save. |
 
 
+#### Before and After Blocks
+
+Use the following syntax to execute code before or after the job runs:
+
+```ruby
+class Deploy < Jobly::Job
+  before do
+    logger.info "Starting"
+  end
+
+  before do
+    logger.info "Done"
+  end
+  
+  def execute
+    puts "Deploying"
+  end
+end
+```
+
+
 Loading Additional Code
 --------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ Compact job server with API, CLI, Web UI and a Sidekiq heart.
     * [Running jobs from the command line](#running-jobs-from-the-command-line)
     * [Running jobs through the API](#running-jobs-through-the-api)
 * [Building Jobs](#building-jobs)
+    * [The Job Class](#the-job-class)
 * [Loading Additional Code](#loading-additional-code)
 * [Configuration](#configuration)
     * [Worker Configuration](#worker-configuration)
+
 ---
 
 Installation
@@ -126,8 +128,11 @@ subfolder inside it. All your job classes go in this folder (configurable).
 
 All job classes will be loaded by any of Jobly's commands.
 
+
+### The Job Class
+
 A job class is a simple Ruby class inheriting from 
-`[Jobly::Job](/lib/jobly/job.rb)`.
+[`Jobly::Job`](/lib/jobly/job.rb).
 
 The only requirement is that your class implements an `execute` method that
 optionally accepts keyword arguments (recommended), or a hash.
@@ -144,12 +149,33 @@ end
 ```
 
 Note that these classes are simply Jobly-flavored sidekiq jobs, with these
-differences:
+key differences:
 
 - You need to implement `execute` instead of `perform`
 - Job arguments are defined as keyword arguments, instead of positional 
   arguments.
 
+#### Job Options
+
+Setting job options can be done like this:
+
+```ruby
+class Deploy < Jobly::Job
+  queue 'critical'
+  backtrace 10
+  retries 3
+  
+  def execute
+    puts "Deploying"
+  end
+end
+```
+
+| Key         | Default   | Purpose       |
+|-------------|-----------|---------------|
+| `queue`     | `default` | set the name of the queue for this job. |
+| `retries`   |  `5`      | number of times to retry on failure. |
+| `backtrace` |  `5`      | number of backtrace lines to show in case of failures. Can be `true`, `false` or a number of lines to save. |
 
 
 Loading Additional Code

--- a/lib/jobly.rb
+++ b/lib/jobly.rb
@@ -2,6 +2,7 @@ require 'requires'
 require 'byebug' if ENV['BYEBUG']
 
 requires 'jobly/refinements'
+requires 'jobly/job_extensions'
 require 'jobly/exceptions'
 require 'jobly/sidekiq'
 require 'jobly/module_functions'

--- a/lib/jobly/job.rb
+++ b/lib/jobly/job.rb
@@ -2,14 +2,12 @@ module Jobly
   class Job
     include Sidekiq::Worker
     include Sidekiq::Status::Worker
+    include JobExtensions::OptionAccessors
 
-    # Set some more appropriate defaults
     sidekiq_options retry: 5, backtrace: 5
+    attr_reader :params
 
     class << self
-      # Allow inheriting jobs to use `options` instead of `sidekiq_options`
-      alias_method :options, :sidekiq_options
-
       # Allow inheriting jobs to use `execute_async` instead of 
       # `perform_async` for consistency with `execute`
       alias_method :execute_async, :perform_async
@@ -28,25 +26,23 @@ module Jobly
 
       # Add support for running code before execution
       def before(&block)
-        before_blocks << block
+        befores << block
       end
 
       # Add support for running code after execution
       def after(&block)
-        after_blocks << block
+        afters << block
       end
 
-      def before_blocks
-        @before_blocks ||= []
+      def befores
+        @befores ||= []
       end
 
-      def after_blocks
-        @after_blocks ||= []
+      def afters
+        @afters ||= []
       end
 
     end
-
-    attr_reader :params
 
     # This is the method sidekiq will call. We capture this call and convert
     # the hash argument which was converted to array on sidekiq's side, back
@@ -54,23 +50,23 @@ module Jobly
     # implement keyword args.
     def perform(params={})
       @params = params
-
-      self.class.before_blocks.each do |block|
-        instance_eval &block
-      end
+      run_blocks self.class.befores
 
       params = params.to_h.transform_keys(&:to_sym)
       params.empty? ? execute : execute(params)
 
-      self.class.after_blocks.each do |block|
-        instance_eval &block
-      end
-
+      run_blocks self.class.afters
     end
 
     # Inheriting classes must implement this method only.
     def execute(params={})
       raise NotImplementedError
+    end
+
+  protected
+
+    def run_blocks(blocks)
+      blocks.each { |block| instance_eval &block }
     end
 
   end

--- a/lib/jobly/job_extensions/option_accessors.rb
+++ b/lib/jobly/job_extensions/option_accessors.rb
@@ -1,0 +1,29 @@
+module Jobly
+  module JobExtensions
+    module OptionAccessors
+
+      def self.included(base)
+        base.extend ClassMethods
+      end
+      
+      module ClassMethods
+        def options
+          sidekiq_options
+        end
+
+        def queue(name)
+          options['queue'] = name
+        end
+
+        def retries(count)
+          options['retry'] = count
+        end
+
+        def backtrace(count)
+          options['backtrace'] = count
+        end
+      end      
+
+    end
+  end
+end

--- a/spec/approvals/job/before-after
+++ b/spec/approvals/job/before-after
@@ -1,0 +1,3 @@
+brush teeth before sleeping for 7 hours
+Sleeping for 7 hours
+get coffee after 7 hours sleep

--- a/spec/approvals/job_extensions/option_accessors
+++ b/spec/approvals/job_extensions/option_accessors
@@ -1,0 +1,2 @@
+executed with these options:
+{"retry"=>3, "queue"=>"are-as-tea", "backtrace"=>11}

--- a/spec/fixtures/jobs/options.rb
+++ b/spec/fixtures/jobs/options.rb
@@ -1,0 +1,10 @@
+class OptionsJob < Jobly::Job
+  queue 'are-as-tea'
+  backtrace 11
+  retries 3
+
+  def execute
+    puts "executed with these options:"
+    p sidekiq_options_hash
+  end
+end

--- a/spec/fixtures/jobs/sleep.rb
+++ b/spec/fixtures/jobs/sleep.rb
@@ -1,0 +1,8 @@
+class Sleep < Jobly::Job
+  before { puts "brush teeth before sleeping for #{params[:this_many]} hours" }
+  after  { puts "get coffee after #{params[:this_many]} hours sleep" }
+
+  def execute(this_many:)
+    puts "Sleeping for #{this_many} hours"
+  end
+end

--- a/spec/jobly/job_extensions/option_accessors_spec.rb
+++ b/spec/jobly/job_extensions/option_accessors_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe JobExtensions::OptionAccessors do
+  subject { OptionsJob }
+
+  it "sets options using accessors" do
+    expect{ OptionsJob.perform }.to output_fixture('job_extensions/option_accessors')
+  end
+end

--- a/spec/jobly/job_spec.rb
+++ b/spec/jobly/job_spec.rb
@@ -29,6 +29,14 @@ describe Job do
     end
   end
 
+  describe '::before and ::after' do
+    subject { Sleep }
+
+    it "run blocks of code around #perform" do
+      expect{ subject.perform this_many: 7 }.to output_fixture('job/before-after')
+    end
+  end
+
   describe '#perform' do
     let(:params) { [["name", "bob"], ["year", 1987]] }
 

--- a/spec/jobly/job_spec.rb
+++ b/spec/jobly/job_spec.rb
@@ -9,12 +9,6 @@ describe Job do
     expect(subject).to respond_to :expiration
   end
 
-  describe '::options' do
-    it "behaves as ::sidekiq_options" do
-      expect(described_class.options).to eq described_class.sidekiq_options
-    end
-  end
-
   describe '::execute_async' do
     it "behaves as ::perform_async" do
       # TODO: Can we test this better?


### PR DESCRIPTION
- Add a `JobExtensions` module, In preparation for adding some job features.
- Add support for `before do` and `after do` in jobs.
- Add support for setting Sidekiq options with direct option accessors
