### PR TITLE
Improve before/after/on_success/on_failure job actions

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -5,6 +5,7 @@ require "irb/completion"
 
 require "jobly"
 require "jobly/jobs"
+require "jobly/boot"
 
 include Jobly
 

--- a/examples/08-before-after-actions/README.md
+++ b/examples/08-before-after-actions/README.md
@@ -1,0 +1,19 @@
+How to use this example
+==================================================
+
+[Download the examples folder](https://minhaskamal.github.io/DownGit/#/home?url=https://github.com/DannyBen/jobly/tree/master/examples)
+and follow the steps below.
+
+This example illustrates the use of `before`, `after`, `on_success`, and 
+`on_failure` blocks.
+
+
+```shell
+cd examples/08-before-after-actions
+
+# Run the job in its successful form
+jobly run Actions
+
+# Run the job in its failed form
+jobly run Actions fail:yes
+```

--- a/examples/08-before-after-actions/jobs/actions.rb
+++ b/examples/08-before-after-actions/jobs/actions.rb
@@ -1,0 +1,19 @@
+class Actions < Jobly::Job
+  before { puts "before" }
+  after  { puts "after" }
+
+  on_success { puts "on_success" }
+  on_failure { puts "on_failure" }
+
+  after :after_party
+
+  def execute(fail: false)
+    puts "execute 1/2"
+    raise "RAISED" if fail
+    puts "execute 2/2"
+  end
+
+  def after_party
+    puts "after_party"
+  end
+end

--- a/lib/jobly/job.rb
+++ b/lib/jobly/job.rb
@@ -34,11 +34,19 @@ module Jobly
     # implement keyword args.
     def perform(params={})
       @params = params
-      run_actions actions[:before]
+      run_actions :before
 
-      params.empty? ? execute : execute(params.to_kwargs)
+      begin
+        params.empty? ? execute : execute(params.to_kwargs)
+        run_actions :success
 
-      run_actions actions[:after]
+      rescue
+        run_actions :failure
+      
+      ensure
+        run_actions :after
+      
+      end
     end
 
     # Inheriting classes must implement this method only.

--- a/lib/jobly/job.rb
+++ b/lib/jobly/job.rb
@@ -42,6 +42,7 @@ module Jobly
 
       rescue
         run_actions :failure
+        raise
       
       ensure
         run_actions :after

--- a/lib/jobly/job_extensions/actions.rb
+++ b/lib/jobly/job_extensions/actions.rb
@@ -1,0 +1,45 @@
+module Jobly
+  module JobExtensions
+    module Actions
+
+      def self.included(base)
+        base.extend ClassMethods
+      end
+
+      module ClassMethods
+        def before(sym = nil, &block)
+          actions[:before] ||= []
+          actions[:before] << (sym || block)
+        end
+
+        def after(sym = nil, &block)
+          actions[:after] ||= []
+          actions[:after] << (sym || block)
+        end
+
+        def actions
+          @actions ||= {}
+        end
+      end
+
+    protected
+
+      def actions
+        self.class.actions
+      end
+
+      def run_actions(list)
+        return unless list
+
+        list.each do |action|
+          if action.is_a? Symbol
+            send action
+          else
+            instance_eval &action
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/jobly/job_extensions/actions.rb
+++ b/lib/jobly/job_extensions/actions.rb
@@ -17,6 +17,16 @@ module Jobly
           actions[:after] << (sym || block)
         end
 
+        def on_success(sym = nil, &block)
+          actions[:success] ||= []
+          actions[:success] << (sym || block)
+        end
+
+        def on_failure(sym = nil, &block)
+          actions[:failure] ||= []
+          actions[:failure] << (sym || block)
+        end
+
         def actions
           @actions ||= {}
         end
@@ -29,9 +39,9 @@ module Jobly
       end
 
       def run_actions(list)
-        return unless list
+        return unless actions[list]
 
-        list.each do |action|
+        actions[list].each do |action|
           if action.is_a? Symbol
             send action
           else

--- a/lib/jobly/refinements/convert_to_typed.rb
+++ b/lib/jobly/refinements/convert_to_typed.rb
@@ -18,6 +18,8 @@ module Jobly
 
     refine String do
       def convert_to_typed
+        return true  if ['true', 'yes'].include? self
+        return false if ['false', 'no'].include? self
         Integer self rescue self
       end
     end

--- a/lib/jobly/refinements/keyword_args.rb
+++ b/lib/jobly/refinements/keyword_args.rb
@@ -1,0 +1,15 @@
+module Jobly
+  module KeywordArgs
+    refine Hash do
+      def to_kwargs
+        to_h.transform_keys &:to_sym
+      end
+    end
+
+    refine Array do
+      def to_kwargs
+        to_h.transform_keys &:to_sym
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add before/after example (closes #6)
- Extract action management to `JobExtensions::Actions`
- Extract hash-to-kwargs to a refinement
- Make `after` block run always, even on failure (closes #12)
- Improve input type conversion to also support booleans (`jobly run SomeJob deploy:yes`)
