### PR TITLE
Allow more config through env vars

### DIFF
--- a/examples/02-full/config/jobly.rb
+++ b/examples/02-full/config/jobly.rb
@@ -42,14 +42,14 @@ Jobly.configure do |config|
   # status_expiration: minutes
   # Sets the number of minutes that completed jobs are kept in the Statuses
   # tab.
-  # Default: 30
+  # Default: ENV['JOBLY_STATUS_EXPIRATION'] || 30
   config.status_expiration = 5
 
   # jobs_namespace: string
   # Sets the namespace (module name) that your jobs are defined in. For 
   # example, if your Job classes are in fact defined as `MyJobs::SomeJob` 
   # then this option should be set to `MyJobs`.
-  # Default: nil (no namespace)
+  # Default: ENV['JOBLY_JOBS_NAMESPACE'] || nil
   config.jobs_namespace = nil
 
   # logger: logger instance

--- a/lib/jobly/module_functions.rb
+++ b/lib/jobly/module_functions.rb
@@ -15,8 +15,8 @@ module Jobly
       jobs_path: ENV['JOBLY_JOBS_PATH'] || "jobs",
       config_path: ENV['JOBLY_CONFIG_PATH'] || "config",
       redis_url: ENV['JOBLY_REDIS_URL'] || "redis://localhost:6379/0",
-      status_expiration: 30,
-      jobs_namespace: nil,
+      status_expiration: ENV['JOBLY_STATUS_EXPIRATION']&.to_i || 30,
+      jobs_namespace: ENV['JOBLY_JOBS_NAMESPACE'],
       logger: nil,
     }
   end


### PR DESCRIPTION
- Add `status_expiration` config with `JOBLY_STATUS_EXPIRATION`
- Add `jobs_namespace` config with `JOBLY_JOBS_NAMESPACE`

Closes #20