### PR TITLE
Improve CLI error catching

### DIFF
--- a/bin/jobly
+++ b/bin/jobly
@@ -1,16 +1,18 @@
 #!/usr/bin/env ruby
 require 'colsole'
-require 'jobly'
-require 'jobly/boot'
-
 include Colsole
 
-router = Jobly::CLI.router
-
 begin
+  require 'jobly'
+  require 'jobly/boot'
+
+  router = Jobly::CLI.router
+
   exit router.run ARGV
+
 rescue => e
   puts e.backtrace.reverse if ENV['DEBUG']
   say! "!txtred!#{e.class}: #{e.message}"
+  say! "Run with !txtpur!DEBUG=1!txtrst! for backtrace details" unless ENV['DEBUG']
   exit 1
 end


### PR DESCRIPTION
Since requiring `jobly` itself might load user generated code, with possible errors, we need to have the binary `rescue` sooner.

In addition, added a hint for the user to use `DEBUG=1 jobly <command>...` in case of an error.