### PR TITLE
Add ability to add custom rack apps

### DIFF
--- a/lib/jobly/config.ru
+++ b/lib/jobly/config.ru
@@ -7,4 +7,10 @@ mounts = {
   '/do' => Jobly::Server
 }
 
-run Rack::URLMap.new mounts
+mounts.merge! Jobly.mounts if Jobly.mounts
+
+if ENV['JOBLY_TEST_MODE']
+  lp mounts
+else
+  run Rack::URLMap.new mounts
+end

--- a/lib/jobly/module_functions.rb
+++ b/lib/jobly/module_functions.rb
@@ -18,6 +18,7 @@ module Jobly
       status_expiration: ENV['JOBLY_STATUS_EXPIRATION']&.to_i || 30,
       jobs_namespace: ENV['JOBLY_JOBS_NAMESPACE'],
       log: ENV['JOBLY_LOG'],
+      mounts: nil,
     }
   end
 

--- a/spec/approvals/cli/config/no-args
+++ b/spec/approvals/cli/config/no-args
@@ -8,4 +8,5 @@
 [0m   status_expiration  [0;32m30
 [0m      jobs_namespace  [0;32m
 [0m                 log  [0;32m
+[0m              mounts  [0;32m
 [0m

--- a/spec/approvals/rackup/default
+++ b/spec/approvals/rackup/default
@@ -1,0 +1,3 @@
+---
+"/": !ruby/class 'Sidekiq::Web'
+"/do": !ruby/class 'Jobly::Server'

--- a/spec/approvals/rackup/mounts
+++ b/spec/approvals/rackup/mounts
@@ -1,0 +1,5 @@
+---
+"/": !ruby/class 'Sidekiq::Web'
+"/do": !ruby/class 'Jobly::Server'
+"/me": MeApp
+"/myself": MyselfAPp

--- a/spec/jobly/rackup_spec.rb
+++ b/spec/jobly/rackup_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'config.ru' do
+  subject { load 'lib/jobly/config.ru' }
+
+  it "works" do
+    expect{ subject }.to output_fixture('rackup/default')
+  end
+
+  context "when there is a Jobly.mount config" do
+    let(:mounts) { { "/me" => "MeApp", "/myself" => "MyselfAPp" } }
+
+    before { Jobly.mounts = mounts }
+    after  { Jobly.mounts = nil }
+
+    it "mounts the additional rack apps" do
+      expect{ subject }.to output_fixture('rackup/mounts')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,8 @@ include Jobly
 require_relative 'spec_mixin'
 system 'mkdir spec/tmp' unless Dir.exist? 'spec/tmp'
 
+ENV['JOBLY_TEST_MODE'] = '1'
+
 RSpec.configure do |c|
   c.include SpecMixin
   c.include Rack::Test::Methods


### PR DESCRIPTION
Additional rack apps can now be mounted by using the `config.mounts` option.

Closes #9 