### PR TITLE
Add support for ruby 2.3 and 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 
 rvm:
+- "2.3.0"
 - "2.5.3"
 
 services:

--- a/jobly.gemspec
+++ b/jobly.gemspec
@@ -15,13 +15,12 @@ Gem::Specification.new do |s|
   s.executables = ['jobly']
   s.homepage    = 'https://github.com/dannyben/jobly'
   s.license     = 'MIT'
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.3.0"
 
   s.add_runtime_dependency 'mister_bin', '~> 0.6'
   s.add_runtime_dependency 'colsole', '~> 0.5'
 
   s.add_runtime_dependency "http", '~> 4.0'
-  s.add_runtime_dependency "lp", '~> 0.1'
   s.add_runtime_dependency "puma", '~> 3.12'
   s.add_runtime_dependency "rack", '~> 2.0'
   s.add_runtime_dependency "remote_syslog_logger", '~> 1.0'

--- a/lib/jobly.rb
+++ b/lib/jobly.rb
@@ -1,6 +1,7 @@
 require 'requires'
 require 'byebug' if ENV['BYEBUG']
 
+requires 'jobly/polyfills'
 requires 'jobly/extensions'
 requires 'jobly/refinements'
 requires 'jobly/job_extensions'

--- a/lib/jobly/commands/base.rb
+++ b/lib/jobly/commands/base.rb
@@ -1,6 +1,6 @@
 require 'mister_bin'
 require 'colsole'
-require 'lp'
+require 'yaml'
 
 module Jobly
   module Commands

--- a/lib/jobly/commands/send.rb
+++ b/lib/jobly/commands/send.rb
@@ -26,7 +26,7 @@ module Jobly
         raise HTTPError, "#{response.code} #{response.reason}" unless response.status.ok?
 
         say "!txtgrn!#{response.code} #{response.reason}"
-        lp response.parse
+        puts response.parse.to_yaml
       end
 
     private

--- a/lib/jobly/polyfills/hash.rb
+++ b/lib/jobly/polyfills/hash.rb
@@ -1,0 +1,17 @@
+# Required for Ruby < 2.4
+if !{}.respond_to? :transform_values
+  class Hash
+    def transform_values
+      self.each { |k, v| self[k] = yield v }
+    end
+  end
+end
+
+# Required for Ruby < 2.5
+if !{}.respond_to? :transform_keys
+  class Hash
+    def transform_keys
+      self.map { |k, v| [(yield k), v] }.to_h
+    end
+  end
+end


### PR DESCRIPTION
Only two methods prevented this gem from being supported on ruby 2.3 and 2.4. These two methods are now polyfilled in these older Ruby versions.