### PR TITLE
Fix logger assignment

### DIFF
--- a/lib/jobly/job.rb
+++ b/lib/jobly/job.rb
@@ -52,7 +52,7 @@ module Jobly
     end
 
     def logger!
-      if !Jobly.log or !Jobly.log.include? "%s"
+      if !Jobly.log
         Sidekiq.logger
       else
         Log.new Jobly.log, self.class.name.to_slug

--- a/spec/jobly/job_spec.rb
+++ b/spec/jobly/job_spec.rb
@@ -47,6 +47,16 @@ describe Job do
     end
 
     context "when Jobly.log is a simple string" do
+      before { Jobly.log = "logs/mylog.log" }
+      after  { Jobly.log = nil }
+
+      it "returns a Log instance" do
+        expect(Log).to receive(:new).with("logs/mylog.log", "jobly-job")
+        subject.logger
+      end
+    end
+
+    context "when Jobly.log is a string with replacement marker" do
       before { Jobly.log = "logs/%s.log" }
       after  { Jobly.log = nil }
 
@@ -55,6 +65,7 @@ describe Job do
         subject.logger
       end
     end
+
 
   end
 end


### PR DESCRIPTION
Setting `Jobly.log` to a string without `%s` was not obeyed.