### PR TITLE
Fix custom logger

### DIFF
--- a/lib/jobly/job.rb
+++ b/lib/jobly/job.rb
@@ -54,6 +54,8 @@ module Jobly
     def logger!
       if !Jobly.log
         Sidekiq.logger
+      elsif Jobly.log.is_a? Logger
+        Jobly.log
       else
         Log.new Jobly.log, self.class.name.to_slug
       end

--- a/lib/jobly/module_functions.rb
+++ b/lib/jobly/module_functions.rb
@@ -49,18 +49,18 @@ module Jobly
   end
 
   def self.logger
-    return nil unless log
-    @logger ||= Log.new log, :jobly
+    @logger
   end
 
   def self.log=(target)
     options[:log] = target
-    @logger = nil
-  end
-
-  def self.logger=(target)
-    options[:log] = :custom
-    @logger = target
+    @logger = if target.is_a? Logger
+      target
+    elsif target
+      Log.new target, :jobly
+    else
+      nil
+    end
   end
 
   def self.full_app_path

--- a/lib/jobly/sidekiq.rb
+++ b/lib/jobly/sidekiq.rb
@@ -20,9 +20,7 @@ module Jobly
         # :nocov:
       end
 
-      if Jobly.log
-        Sidekiq.logger = Log.new Jobly.log, :sidekiq
-      end
+      Sidekiq.logger = Jobly.logger if Jobly.log
     end
   end
 end

--- a/spec/jobly/job_spec.rb
+++ b/spec/jobly/job_spec.rb
@@ -66,6 +66,16 @@ describe Job do
       end
     end
 
+    context "when Jobly.log is a Logger" do
+      let(:logger) { Logger.new "spec/tmp/custom_logger.log" }
+
+      before { Jobly.log = logger }
+      after  { Jobly.log = nil }
+
+      it "returns the custom logger" do
+        expect(subject.logger).to eq logger
+      end
+    end
 
   end
 end

--- a/spec/jobly/job_spec.rb
+++ b/spec/jobly/job_spec.rb
@@ -47,21 +47,21 @@ describe Job do
     end
 
     context "when Jobly.log is a simple string" do
-      before { Jobly.log = "logs/mylog.log" }
+      before { Jobly.log = "log/mylog.log" }
       after  { Jobly.log = nil }
 
       it "returns a Log instance" do
-        expect(Log).to receive(:new).with("logs/mylog.log", "jobly-job")
+        expect(Log).to receive(:new).with("log/mylog.log", "jobly-job")
         subject.logger
       end
     end
 
     context "when Jobly.log is a string with replacement marker" do
-      before { Jobly.log = "logs/%s.log" }
+      before { Jobly.log = "log/%s.log" }
       after  { Jobly.log = nil }
 
       it "returns a tagged Log with the class name" do
-        expect(Log).to receive(:new).with("logs/%s.log", "jobly-job")
+        expect(Log).to receive(:new).with("log/%s.log", "jobly-job")
         subject.logger
       end
     end

--- a/spec/jobly/job_spec.rb
+++ b/spec/jobly/job_spec.rb
@@ -47,21 +47,21 @@ describe Job do
     end
 
     context "when Jobly.log is a simple string" do
-      before { Jobly.log = "log/mylog.log" }
+      before { Jobly.log = "spec/tmp/mylog.log" }
       after  { Jobly.log = nil }
 
       it "returns a Log instance" do
-        expect(Log).to receive(:new).with("log/mylog.log", "jobly-job")
+        expect(Log).to receive(:new).with("spec/tmp/mylog.log", "jobly-job")
         subject.logger
       end
     end
 
     context "when Jobly.log is a string with replacement marker" do
-      before { Jobly.log = "log/%s.log" }
+      before { Jobly.log = "spec/tmp/%s.log" }
       after  { Jobly.log = nil }
 
       it "returns a tagged Log with the class name" do
-        expect(Log).to receive(:new).with("log/%s.log", "jobly-job")
+        expect(Log).to receive(:new).with("spec/tmp/%s.log", "jobly-job")
         subject.logger
       end
     end

--- a/spec/jobly/module_functions_spec.rb
+++ b/spec/jobly/module_functions_spec.rb
@@ -73,20 +73,6 @@ describe Jobly do
     end
   end
 
-  describe '::logger=' do
-    after { described_class.log = nil }
-
-    it "set a logger" do
-      described_class.logger = Logger.new STDOUT
-      expect(described_class.logger).to be_a Logger
-    end
-
-    it "sets Jobly.log to :custom" do
-      described_class.logger = Logger.new STDOUT
-      expect(described_class.log).to eq :custom
-    end
-  end
-
   describe '::configure' do
     it "yields self" do
       yielded_instance = nil


### PR DESCRIPTION
There was a little messy collision between `Jobly.log` and `Jobly.logger`. This PR fixes it with a **breaking change**:

`Jobly.logger = some_logger` is no longer available. Instead, the `Jobly.log` can now also accept a logger, so:

```ruby
# if you were using this:
Jobly.logger = logger_instance

# replace it with this:
Jobly.log = logger_instance
```

Closes #53