### PR TITLE
Add JOBLY_SHELL_DRY_RUN

### DIFF
--- a/lib/jobly/helpers/shell.rb
+++ b/lib/jobly/helpers/shell.rb
@@ -3,7 +3,13 @@ require 'tty-command'
 module Jobly
   module Shell
     def shell
-      @shell ||= TTY::Command.new(output: logger, color: false)
+      @shell ||= shell!
+    end
+
+    def shell!
+      TTY::Command.new output: logger, 
+        color: false,
+        dry_run: !!ENV['JOBLY_SHELL_DRY_RUN']
     end
   end
 end

--- a/lib/jobly/helpers/slack.rb
+++ b/lib/jobly/helpers/slack.rb
@@ -28,8 +28,6 @@ module Jobly
       @slack ||= slack!
     end
 
-  private
-
     def slack!
       raise ArgumentError, "Slack webhook is not set" unless Jobly.slack_webhook
       opts = {

--- a/spec/jobly/helpers/shell_spec.rb
+++ b/spec/jobly/helpers/shell_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Shell do
   subject { Greet.new }
 
-  describe '#shell', :focus do
+  describe '#shell' do
     it "returns a TTY::Command instance" do
       expect(subject.shell).to be_a TTY::Command
     end

--- a/spec/jobly/helpers/shell_spec.rb
+++ b/spec/jobly/helpers/shell_spec.rb
@@ -3,9 +3,22 @@ require 'spec_helper'
 describe Shell do
   subject { Greet.new }
 
-  describe '#shell' do
+  describe '#shell', :focus do
     it "returns a TTY::Command instance" do
       expect(subject.shell).to be_a TTY::Command
+    end
+
+    it "does not enable dry_run mode" do
+      expect(subject.shell.dry_run?).to be false
+    end
+
+    context "when JOBLY_SHELL_DRY_RUN is set" do
+      before { ENV['JOBLY_SHELL_DRY_RUN'] = '1' }
+      after  { ENV['JOBLY_SHELL_DRY_RUN'] = nil }
+
+      it "enables dry_run mode" do
+        expect(subject.shell.dry_run?).to be true
+      end
     end
   end
 


### PR DESCRIPTION
Allow setting the `shell` helper to dry run mode by setting the `JOBLY_SHELL_DRY_RUN` environment variable.