### PR TITLE
Fix relative paths issues and add Jobly.log_level

### DIFF
--- a/lib/jobly/helpers/logging.rb
+++ b/lib/jobly/helpers/logging.rb
@@ -7,13 +7,16 @@ module Jobly
     end
 
     def logger!
-      if !Jobly.log
+      logger = if !Jobly.log
         Sidekiq.logger
       elsif Jobly.log.is_a? Logger
         Jobly.log
       else
-        Log.new Jobly.log, self.class.name.to_slug
+        Log.new Jobly.full_log_path, self.class.name.to_slug
       end
+
+      logger.level = Jobly.log_level if logger and logger.respond_to? :level
+      logger
     end
   end
 end

--- a/lib/jobly/helpers/logging.rb
+++ b/lib/jobly/helpers/logging.rb
@@ -12,7 +12,7 @@ module Jobly
       elsif Jobly.log.is_a? Logger
         Jobly.log
       else
-        Log.new Jobly.full_log_path, self.class.name.to_slug
+        Log.new Jobly.log, self.class.name.to_slug
       end
 
       logger.level = Jobly.log_level if logger and logger.respond_to? :level

--- a/lib/jobly/log.rb
+++ b/lib/jobly/log.rb
@@ -14,7 +14,7 @@ module Jobly
       if target.start_with? 'syslog://'
         remote_syslog_logger target
       else
-        Logger.new target
+        Logger.new File.expand_path(target, Jobly.root)
       end
     end
 

--- a/lib/jobly/module_functions.rb
+++ b/lib/jobly/module_functions.rb
@@ -81,10 +81,6 @@ module Jobly
       File.expand_path config_path, root
     end
 
-    def full_log_path
-      File.expand_path log, root
-    end
-
     def config_file
       File.expand_path 'jobly.rb', full_config_path
     end

--- a/lib/jobly/module_functions.rb
+++ b/lib/jobly/module_functions.rb
@@ -1,85 +1,96 @@
 module Jobly
-  def self.configure
-    yield self
-  end
-
-  def self.load_custom_config
-    require config_file if File.exist? config_file
-  end
-
-  def self.default_options
-    {
-      environment: ENV['JOBLY_ENVIRONMENT'] || 'development',
-      api_url: ENV['JOBLY_API_URL'] || 'http://localhost:3000/do',
-      app_path: ENV['JOBLY_APP_PATH'] || 'app',
-      jobs_path: ENV['JOBLY_JOBS_PATH'] || "jobs",
-      config_path: ENV['JOBLY_CONFIG_PATH'] || "config",
-      redis_url: ENV['JOBLY_REDIS_URL'] || "redis://localhost:6379/0",
-      status_expiration: ENV['JOBLY_STATUS_EXPIRATION']&.to_i || 30,
-      jobs_namespace: ENV['JOBLY_JOBS_NAMESPACE'],
-      slack_webhook: ENV['JOBLY_SLACK_WEBHOOK'],
-      slack_channel: ENV['JOBLY_SLACK_CHANNEL'] || "#general",
-      slack_user: ENV['JOBLY_SLACK_USER'] || "Jobly",
-      log: ENV['JOBLY_LOG'],
-      auth: ENV['JOBLY_AUTH'],
-      mounts: nil,
-    }
-  end
-
-  def self.method_missing(method, args=nil, &_block)
-    key = method.to_s
-    assign = key[-1] == "="
-    key = key.chomp('=') if assign
-    key = key.to_sym
-
-    if options.has_key? key
-      assign ? options[key] = args : options[key]
-    else
-      super
+  class << self
+    def configure
+      yield self
     end
-  end
 
-  def self.respond_to_missing?(method, include_private=false)
-    key = method.to_s.chomp('=').to_sym
-    options.has_key?(key) ? true : super
-  end
-
-  def self.options
-    @options ||= default_options.dup
-  end
-
-  def self.logger
-    @logger
-  end
-
-  def self.log=(target)
-    options[:log] = target
-    @logger = if target.is_a? Logger
-      target
-    elsif target
-      Log.new target, :jobly
-    else
-      nil
+    def load_custom_config
+      require config_file if File.exist? config_file
     end
-  end
 
-  def self.full_app_path
-    File.expand_path app_path
-  end
+    def default_options
+      {
+        root: Dir.pwd,
+        environment: ENV['JOBLY_ENVIRONMENT'] || 'development',
+        api_url: ENV['JOBLY_API_URL'] || 'http://localhost:3000/do',
+        app_path: ENV['JOBLY_APP_PATH'] || 'app',
+        jobs_path: ENV['JOBLY_JOBS_PATH'] || "jobs",
+        config_path: ENV['JOBLY_CONFIG_PATH'] || "config",
+        redis_url: ENV['JOBLY_REDIS_URL'] || "redis://localhost:6379/0",
+        status_expiration: ENV['JOBLY_STATUS_EXPIRATION']&.to_i || 30,
+        jobs_namespace: ENV['JOBLY_JOBS_NAMESPACE'],
+        slack_webhook: ENV['JOBLY_SLACK_WEBHOOK'],
+        slack_channel: ENV['JOBLY_SLACK_CHANNEL'] || "#general",
+        slack_user: ENV['JOBLY_SLACK_USER'] || "Jobly",
+        log: ENV['JOBLY_LOG'],
+        log_level: ENV['JOBLY_LOG_LEVEL'] || 'info',
+        auth: ENV['JOBLY_AUTH'],
+        mounts: nil,
+      }
+    end
 
-  def self.full_jobs_path
-    File.expand_path jobs_path
-  end
+    def method_missing(method, args=nil, &_block)
+      key = method.to_s
+      assign = key[-1] == "="
+      key = key.chomp('=') if assign
+      key = key.to_sym
 
-  def self.full_config_path
-    File.expand_path config_path
-  end
+      if options.has_key? key
+        assign ? options[key] = args : options[key]
+      else
+        super
+      end
+    end
 
-  def self.config_file
-    File.expand_path 'jobly.rb', self.config_path
-  end
+    def respond_to_missing?(method, include_private=false)
+      key = method.to_s.chomp('=').to_sym
+      options.has_key?(key) ? true : super
+    end
 
-  def self.custom_config?
-    File.exist? config_file
+    def options
+      @options ||= default_options.dup
+    end
+
+    def logger
+      @logger
+    end
+
+    def log=(target)
+      options[:log] = target
+      @logger = if target.is_a? Logger
+        target
+      elsif target
+        Log.new target, :jobly
+      else
+        nil
+      end
+
+      @logger.level = log_level if @logger and @logger.respond_to? :level
+      @logger
+    end
+
+    def full_app_path
+      File.expand_path app_path, root
+    end
+
+    def full_jobs_path
+      File.expand_path jobs_path, root
+    end
+
+    def full_config_path
+      File.expand_path config_path, root
+    end
+
+    def full_log_path
+      File.expand_path log, root
+    end
+
+    def config_file
+      File.expand_path 'jobly.rb', full_config_path
+    end
+
+    def custom_config?
+      File.exist? config_file
+    end
   end
 end

--- a/lib/jobly/templates/full/config/jobly.rb
+++ b/lib/jobly/templates/full/config/jobly.rb
@@ -10,6 +10,7 @@ Jobly.configure do |config|
   # config.status_expiration = 30
   # config.jobs_namespace = 'Jobs'
   # config.log = 'log/%s.log'
+  # config.log_level = 'info'
   # config.slack_webhook = 'https://hooks.slack.com/services/...'
   # config.slack_channel = '#debug'
   # config.slack_user = 'Botly'

--- a/spec/approvals/cli/config/no-args
+++ b/spec/approvals/cli/config/no-args
@@ -1,5 +1,5 @@
   custom config file  ...jobly.rb
-[0m                root  [0;32m/vagrant/gems/jobly
+[0m                root  ...jobly
 [0m         environment  [0;32mdevelopment
 [0m             api_url  [0;32mhttp://localhost:3000/do
 [0m            app_path  [0;31mapp

--- a/spec/approvals/cli/config/no-args
+++ b/spec/approvals/cli/config/no-args
@@ -1,4 +1,5 @@
   custom config file  ...jobly.rb
+[0m                root  [0;32m/vagrant/gems/jobly
 [0m         environment  [0;32mdevelopment
 [0m             api_url  [0;32mhttp://localhost:3000/do
 [0m            app_path  [0;31mapp
@@ -8,4 +9,5 @@
 [0m   status_expiration  [0;32m30
 [0m       slack_channel  [0;32m#general
 [0m          slack_user  [0;32mJobly
+[0m           log_level  [0;32minfo
 [0m

--- a/spec/jobly/commands/config_spec.rb
+++ b/spec/jobly/commands/config_spec.rb
@@ -7,6 +7,7 @@ describe Commands::ConfigCmd do
     it "shows config options" do
       expect{ subject.run %w[config] }.to output_fixture('cli/config/no-args')
         .except(/custom config file  (.*)jobly.rb/)
+        .except(/root  (.*)jobly/)
     end
   end
 

--- a/spec/jobly/job_spec.rb
+++ b/spec/jobly/job_spec.rb
@@ -51,7 +51,7 @@ describe Job do
       after  { Jobly.log = nil }
 
       it "returns a Log instance" do
-        expect(Log).to receive(:new).with("spec/tmp/mylog.log", "jobly-job")
+        expect(Log).to receive(:new).with(%r{spec/tmp/mylog.log}, "jobly-job")
         subject.logger
       end
     end
@@ -61,7 +61,7 @@ describe Job do
       after  { Jobly.log = nil }
 
       it "returns a tagged Log with the class name" do
-        expect(Log).to receive(:new).with("spec/tmp/%s.log", "jobly-job")
+        expect(Log).to receive(:new).with(%r{spec/tmp/%s.log}, "jobly-job")
         subject.logger
       end
     end

--- a/spec/jobly/log_spec.rb
+++ b/spec/jobly/log_spec.rb
@@ -1,4 +1,4 @@
- 'spec_helper'
+require 'spec_helper'
 
 describe Log do
   subject { described_class.new }
@@ -23,9 +23,9 @@ describe Log do
     context "with target = filename" do
       subject { described_class.new 'spec/tmp/log.log' }
 
-      it "returns a file Logger" do
+      it "returns a file Logger with full path" do
         expect(subject.instance_variable_get(:@logdev).dev.inspect)
-          .to eq "#<File:spec/tmp/log.log>"
+          .to match %r{#<File:/(.*)spec/tmp/log.log>}
       end
 
       context "with tag = something" do
@@ -33,7 +33,7 @@ describe Log do
 
         it "places the tag in the file path" do
           expect(subject.instance_variable_get(:@logdev).dev.inspect)
-            .to eq "#<File:spec/tmp/something.log>"
+            .to match %r{#<File:/(.*)spec/tmp/something.log>}
         end
       end
     end

--- a/spec/jobly/module_functions_spec.rb
+++ b/spec/jobly/module_functions_spec.rb
@@ -5,6 +5,7 @@ describe Jobly do
     %i[
       environment api_url app_path full_app_path jobs_path full_jobs_path
       config_path full_config_path redis_url slack_channel slack_user
+      log_level root
     ]
   end
 
@@ -43,6 +44,22 @@ describe Jobly do
 
       expect(described_class.logger.instance_variable_get(:@logdev).dev.inspect)
         .to eq "#<File:spec/tmp/out.log>"
+    end
+
+    it "sets the default log level to info" do
+      described_class.log = 'spec/tmp/out.log'
+      expect(described_class.logger.level).to eq 1
+    end
+  end
+
+  describe '::log_level=' do
+    after { described_class.log = nil }
+
+    it "sets the log level for the logger" do
+      expect(described_class.log_level).to eq 'info'
+      described_class.log_level = 'fatal'
+      described_class.log = 'spec/tmp/out.log'
+      expect(described_class.logger.level).to eq 4
     end
   end
 

--- a/spec/jobly/module_functions_spec.rb
+++ b/spec/jobly/module_functions_spec.rb
@@ -43,7 +43,7 @@ describe Jobly do
       described_class.log = 'spec/tmp/out.log'
 
       expect(described_class.logger.instance_variable_get(:@logdev).dev.inspect)
-        .to eq "#<File:spec/tmp/out.log>"
+        .to match %r{#<File:/(.*)spec/tmp/out.log>}
     end
 
     it "sets the default log level to info" do


### PR DESCRIPTION
When doing `Dir.chdir` inside a job, some of Jobly's paths stop functioning (since they are lazy-loaded).
For example, if (as it is by default) logging path is just the relative `logs`, then Jobly will log to the wrong places.

This PR fixes this and more.

- Add `log_level` to the config
- Fix logger so it always uses absolute path
- Add `Jobly.root` that points to the root Jobly folder
