### PR TITLE
Improve app boot

### DIFF
--- a/lib/jobly/helpers/shell.rb
+++ b/lib/jobly/helpers/shell.rb
@@ -9,7 +9,7 @@ module Jobly
     def shell!
       TTY::Command.new output: logger, 
         color: false,
-        dry_run: !!ENV['JOBLY_SHELL_DRY_RUN']
+        dry_run: !!Jobly.shell_dry_run
     end
   end
 end

--- a/lib/jobly/jobs.rb
+++ b/lib/jobly/jobs.rb
@@ -11,8 +11,10 @@ module Jobly
     end
 
     def self.load_all
-      Dir["#{Jobly.full_app_path}/**/*.rb"].each { |file| require file }
-      Dir["#{Jobly.full_jobs_path}/**/*.rb"].each { |file| require file }
+      user_bootfile = "#{Jobly.full_app_path}/boot.rb"
+      require user_bootfile if File.exist? user_bootfile
+      Dir["#{Jobly.full_app_path}/**/*.rb"].sort.each { |file| require file }
+      Dir["#{Jobly.full_jobs_path}/**/*.rb"].sort.each { |file| require file }
     end
 
     def self.full_job_name(job)

--- a/lib/jobly/module_functions.rb
+++ b/lib/jobly/module_functions.rb
@@ -25,6 +25,7 @@ module Jobly
         log: ENV['JOBLY_LOG'],
         log_level: ENV['JOBLY_LOG_LEVEL'] || 'info',
         auth: ENV['JOBLY_AUTH'],
+        shell_dry_run: ENV['JOBLY_SHELL_DRY_RUN'],
         mounts: nil,
       }
     end

--- a/lib/jobly/templates/full/app/boot.rb
+++ b/lib/jobly/templates/full/app/boot.rb
@@ -1,0 +1,1 @@
+# If this file exists, it will be loaded before everything else

--- a/lib/jobly/templates/full/config/jobly.rb
+++ b/lib/jobly/templates/full/config/jobly.rb
@@ -13,6 +13,7 @@ Jobly.configure do |config|
   # config.log_level = 'info'
   # config.slack_webhook = 'https://hooks.slack.com/services/...'
   # config.slack_channel = '#debug'
-  # config.slack_user = 'Botly'
+  # config.slack_user = 'Jobly'
   # config.auth = 'admin:secret'
+  # config.shell_dry_run = false
 end

--- a/spec/approvals/cli/config/no-args
+++ b/spec/approvals/cli/config/no-args
@@ -2,7 +2,7 @@
 [0m                root  ...jobly
 [0m         environment  [0;32mdevelopment
 [0m             api_url  [0;32mhttp://localhost:3000/do
-[0m            app_path  [0;31mapp
+[0m            app_path  [0;32mspec/fixtures/app
 [0m           jobs_path  [0;32mspec/fixtures/jobs
 [0m         config_path  [0;32mspec/fixtures/config
 [0m           redis_url  [0;32mredis://localhost:6379/0

--- a/spec/approvals/cli/init/full
+++ b/spec/approvals/cli/init/full
@@ -1,6 +1,7 @@
 Created full workspace in spec/tmp/scaffold:
 - spec/tmp/scaffold/Gemfile
 - spec/tmp/scaffold/Procfile
+- spec/tmp/scaffold/app/boot.rb
 - spec/tmp/scaffold/app/job.rb
 - spec/tmp/scaffold/app/other_class.rb
 - spec/tmp/scaffold/config/info.md

--- a/spec/fixtures/app/another_class.rb
+++ b/spec/fixtures/app/another_class.rb
@@ -1,0 +1,3 @@
+# ... and then this file loads with the rest of the app/* files
+class AnotherClass < SomeClass
+end

--- a/spec/fixtures/app/boot.rb
+++ b/spec/fixtures/app/boot.rb
@@ -1,0 +1,3 @@
+# testing that boot loads first...
+class SomeClass
+end

--- a/spec/jobly/helpers/shell_spec.rb
+++ b/spec/jobly/helpers/shell_spec.rb
@@ -12,9 +12,9 @@ describe Shell do
       expect(subject.shell.dry_run?).to be false
     end
 
-    context "when JOBLY_SHELL_DRY_RUN is set" do
-      before { ENV['JOBLY_SHELL_DRY_RUN'] = '1' }
-      after  { ENV['JOBLY_SHELL_DRY_RUN'] = nil }
+    context "when Jobly.shell_dry_run is true" do
+      before { Jobly.shell_dry_run = true }
+      after  { Jobly.shell_dry_run = false }
 
       it "enables dry_run mode" do
         expect(subject.shell.dry_run?).to be true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,10 @@ require 'bundler'
 Bundler.require :default, :development
 
 require 'jobly'
+Jobly.app_path = 'spec/fixtures/app'
 Jobly.jobs_path = 'spec/fixtures/jobs'
 Jobly.config_path = 'spec/fixtures/config'
+
 require 'jobly/boot'
 
 include Jobly


### PR DESCRIPTION
- Improvements to app boot sequence - (closes #64):
   - Both `app` and `jobs` folders will be sorted and then loaded, for OS consistency
   - If the `app` folder contains `boot.rb` it will be loaded first, to allow users to fine tune loading sequence
- Expose `JOBLY_SHELL_DRY_RUN` as a ruby config as well - `Jobly.shell_dry_run` - (closes #63)
