### PR TITLE
Add isolation and change perform_async to run_later

### DIFF
--- a/lib/jobly/api.rb
+++ b/lib/jobly/api.rb
@@ -62,9 +62,9 @@ module Jobly
 
       args = args.convert_to_typed
       if args.empty?
-        job_class.perform_async
+        job_class.run_later
       else
-        job_class.perform_async args
+        job_class.run_later args
       end
       
       response = {

--- a/lib/jobly/commands/run.rb
+++ b/lib/jobly/commands/run.rb
@@ -22,14 +22,14 @@ module Jobly
         if args['--later']
           say "Scheduling !txtgrn!#{job_class}"
           if params.empty?
-            job_class.perform_async
+            job_class.run_later
           else
-            job_class.perform_async params
+            job_class.run_later params
           end
         
         else
           say "Running !txtgrn!#{job_class}"
-          job_class.new.perform params
+          job_class.run params
         end
       end
 

--- a/lib/jobly/job.rb
+++ b/lib/jobly/job.rb
@@ -5,6 +5,7 @@ module Jobly
     include JobExtensions::OptionAccessors
     include JobExtensions::Actions
     include JobExtensions::Solo
+    include JobExtensions::Isolation
 
     # Helpers must come after Sidekiq::Worker since they both bring logger
     # and our logger is the king of loggers
@@ -17,35 +18,36 @@ module Jobly
     attr_reader :params
 
     class << self
-      # Allow inheriting jobs to use `execute_async` instead of 
-      # `perform_async` for consistency with `execute`
-      alias_method :execute_async, :perform_async
-
-      # Allow calling a job with `JobName.execute` instead of 
-      # `JobName.new.execute`, for consistency.
-      def execute(*args)
-        perform *args
+      # Allow running a job with `JobName.run`
+      def run(params = {})
+        new.perform params
       end
 
-      # Allow calling a job with `JobName.perform` instead of 
-      # `JobName.new.perform`, for consistency.
-      def perform(*args)
-        new.perform *args
+      # Allow running a job asynchronously with `JobName.run_later`
+      def run_later(params = {})
+        perform_async params
       end
-
     end
 
     # This is the method sidekiq will call. We capture this call and convert
     # the hash argument which was converted to array on sidekiq's side, back
     # to a hash so we can forward to the job's `execute` method, which may 
     # implement keyword args.
-    def perform(params={})
+    def perform(params = {})
+      if isolated?
+        in_isolation { perform! params }
+      else
+        perform! params
+      end
+    end
+
+    def perform!(params = {})
       @params = params
       run_to_completion if run_before_filter
     end
 
     # Inheriting classes must implement this method only.
-    def execute(params={})
+    def execute(params = {})
       raise NotImplementedError
     end
 

--- a/lib/jobly/job_extensions/isolation.rb
+++ b/lib/jobly/job_extensions/isolation.rb
@@ -1,0 +1,27 @@
+module Jobly
+  module JobExtensions
+    module Isolation
+      def self.included(base)
+        base.extend ClassMethods
+      end
+
+      module ClassMethods
+        attr_reader :isolate
+
+        def isolated(enabled = true)
+          @isolate = enabled
+        end
+      end
+
+      def in_isolation
+        Dir.mktmpdir 'jobly-' do |dir|
+          Dir.chdir(dir) { yield }
+        end
+      end
+
+      def isolated?
+        self.class.isolate
+      end
+    end
+  end
+end

--- a/spec/fixtures/jobs/isolated.rb
+++ b/spec/fixtures/jobs/isolated.rb
@@ -1,0 +1,7 @@
+class IsolatedJob < Jobly::Job
+  isolated
+
+  def execute
+    puts Dir.pwd
+  end
+end

--- a/spec/jobly/job_extensions/actions_spec.rb
+++ b/spec/jobly/job_extensions/actions_spec.rb
@@ -4,12 +4,12 @@ describe JobExtensions::Actions do
   subject { ActionsJob }
 
   it "run blocks of code around #perform" do
-    expect{ subject.perform }.to output_fixture('job_extensions/actions')
+    expect{ subject.run }.to output_fixture('job_extensions/actions')
   end
 
   describe "when a job fails" do
     it "still runs after and on_failure" do
-      expect{ subject.perform fail:true }.to raise_error("RAISED")
+      expect{ subject.run fail:true }.to raise_error("RAISED")
         .and output_fixture('job_extensions/actions-failure')
     end
   end
@@ -18,7 +18,7 @@ describe JobExtensions::Actions do
     subject { FilterJob }
 
     it "avoid running the job and raises JobSkipped" do
-      expect{ subject.perform }.to output_fixture('job_extensions/actions-skip')
+      expect{ subject.run }.to output_fixture('job_extensions/actions-skip')
     end
     
   end

--- a/spec/jobly/job_extensions/isolation_spec.rb
+++ b/spec/jobly/job_extensions/isolation_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe JobExtensions::Isolation do
+  subject { IsolatedJob }
+
+  it "makes the job run in a tmp folder" do
+    expect{ subject.run }.to output(%r{/tmp/jobly-.+}).to_stdout
+  end
+
+end

--- a/spec/jobly/job_extensions/option_accessors_spec.rb
+++ b/spec/jobly/job_extensions/option_accessors_spec.rb
@@ -4,6 +4,6 @@ describe JobExtensions::OptionAccessors do
   subject { OptionsJob }
 
   it "sets options using accessors" do
-    expect{ OptionsJob.perform }.to output_fixture('job_extensions/option_accessors')
+    expect{ subject.run }.to output_fixture('job_extensions/option_accessors')
   end
 end

--- a/spec/jobly/job_spec.rb
+++ b/spec/jobly/job_spec.rb
@@ -9,25 +9,17 @@ describe Job do
     expect(subject).to respond_to :expiration
   end
 
-  describe '::execute_async' do
+  describe '::run_later' do
     it "behaves as ::perform_async" do
-      # TODO: Can we test this better?
-      expect(described_class).to respond_to :perform_async
+      expect(described_class).to receive(:perform_async).with({hello: 'world'})
+      described_class.run_later hello: 'world'
     end
   end
 
-  describe '::execute' do
-    it "calls execute on a new instance" do
-      expect_any_instance_of(described_class).to receive(:execute).with name: 'jill'
-      described_class.execute name: 'jill'
-    end
-
-    context "when the job defines actions" do
-      subject { ActionsJob }
-
-      it "executes the actions" do
-        expect{ subject.execute }.to output_fixture('job/execute-runs-actions')
-      end
+  describe '::run' do
+    it "calls perform on a new instance" do
+      expect_any_instance_of(described_class).to receive(:perform).with name: 'jill'
+      described_class.run name: 'jill'
     end
   end
 


### PR DESCRIPTION
### Breaking changes:

- Renamed `Job::perform_async` to `Job::run_later`.
- Renamed `Job::perform` to `Job::run` (note: class level only).
- Removed `Job::execute_async` - use `Job::run_later` instead.
- Removed `Job::execute` - use `Job::run` instead (note: class level only).

### Other changes:

- Added a new job extension: Isolation. This extension lets you define a job as `isolated` and it will then run in a temporary folder of its own.