### PR TITLE
Upgrade Sting so that we have ExtendedYAML

### DIFF
--- a/jobly.gemspec
+++ b/jobly.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "sinatra", '~> 2.0'
   s.add_runtime_dependency "sinatra-contrib", '~> 2.0'
   s.add_runtime_dependency "slack-notifier", '~> 2.3'
-  s.add_runtime_dependency "sting", '~> 0.3'
+  s.add_runtime_dependency "sting", '~> 0.4'
   s.add_runtime_dependency "tty-command", '~> 0.9'
   s.add_runtime_dependency "tty-markdown", '~> 0.6'
   s.add_runtime_dependency 'colsole', '~> 0.6'

--- a/spec/fixtures/config/settings-parent.yml
+++ b/spec/fixtures/config/settings-parent.yml
@@ -1,0 +1,1 @@
+parent_loaded: true

--- a/spec/fixtures/config/settings.yml
+++ b/spec/fixtures/config/settings.yml
@@ -1,1 +1,2 @@
+extends: settings-parent
 host: localhost

--- a/spec/jobly/helpers/settings_spec.rb
+++ b/spec/jobly/helpers/settings_spec.rb
@@ -12,6 +12,10 @@ describe Settings do
       expect(subject.settings.host).to eq "localhost"
     end
 
+    it "loads extended YAMLs" do
+      expect(subject.settings.parent_loaded).to be true
+    end
+
     context "when Jobly.environment is set" do
       before do
         @original_environment = Jobly.environment


### PR DESCRIPTION
Version 0.4.0 of the `Sting` gem (which is used by the settings helper) brings [ExtendedYAML](https://github.com/dannyben/extended_yaml), so we can use `extends` in Jobly settings now.

This PR updates dependency version and relevant specs.