### PR TITLE
Fix broken remove button by adding 'use Rack::MethodOverride'

### DIFF
--- a/lib/jobly/server.rb
+++ b/lib/jobly/server.rb
@@ -16,6 +16,8 @@ module Jobly
       mounts.merge! Jobly.mounts if Jobly.mounts
 
       Rack::Builder.new do
+        use Rack::MethodOverride
+
         if Jobly.auth
           user, pass = Jobly.auth.split ':'
           use Rack::Auth::Basic, "Jobly" do |username, password|


### PR DESCRIPTION
Fix the "Remove" button that was leading to a 404 page by using the appropriate rack middleware.

Made possible thanks to a comment by @makotoshimoda on https://github.com/utgarda/sidekiq-status/issues/145#issuecomment-749413288 and the subsequent documentation PR https://github.com/utgarda/sidekiq-status/pull/159