### PR TITLE
Fix isolated job test when tmpdir is not in /tmp

### DIFF
--- a/spec/jobly/job_extensions/isolation_spec.rb
+++ b/spec/jobly/job_extensions/isolation_spec.rb
@@ -5,7 +5,8 @@ describe JobExtensions::Isolation do
     subject { IsolatedJob }
 
     it 'runs in a tmp folder' do
-      expect { subject.run }.to output(%r{/tmp/jobly-.+}).to_stdout
+      tmpdir_prefix = File.join(Dir.tmpdir, 'jobly-')
+      expect { subject.run }.to output(/#{Regexp.escape(tmpdir_prefix)}.+/).to_stdout
     end
   end
 


### PR DESCRIPTION
This updates the job isolation test to look for a path in `Dir.tmpdir` rather than expecting it to be in `/tmp`. This fixes the test when run on macOS.

Background: Where `Dir.mktmpdir` creates its temporary directories is [system dependent](https://github.com/ruby/ruby/blob/v3_2_2/lib/tmpdir.rb#L22). On macOS they’re created in `/private/var/folders/<uid_hash>/<uuid_hash>/T/` by default (which Ruby [gets from `_CS_DARWIN_USER_TEMP_DIR`](https://github.com/ruby/ruby/blob/v3_2_2/ext/etc/etc.c#L684-L725)).